### PR TITLE
fix: Calling Fp2.Generator() no longer fails

### DIFF
--- a/field/fp2.go
+++ b/field/fp2.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"reflect"
 )
 
 type fp2Elt [2]fpElt
@@ -38,12 +39,16 @@ func (f *fp2) precmp() {
 }
 
 func (f fp2) Elt(in interface{}) Elt {
-	if v, ok := in.([]interface{}); ok && len(v) == 2 {
+
+	v := reflect.ValueOf(in)
+
+	if (v.Kind() == reflect.Slice || v.Kind() == reflect.Array) && v.Len() == 2 {
 		return &fp2Elt{
-			*(f.base.Elt(v[0]).(*fpElt)),
-			*(f.base.Elt(v[1]).(*fpElt)),
+			*(f.base.Elt(v.Index(0).Interface()).(*fpElt)),
+			*(f.base.Elt(v.Index(1).Interface()).(*fpElt)),
 		}
 	}
+
 	return &fp2Elt{
 		*(f.base.Elt(in).(*fpElt)),
 		*(f.base.Zero().(*fpElt)),

--- a/field/fp2_test.go
+++ b/field/fp2_test.go
@@ -7,6 +7,12 @@ import (
 	GF "github.com/armfazh/tozan-ecc/field"
 )
 
+func TestGeneratorF2(t *testing.T) {
+	// Field taken from https://github.com/armfazh/h2c-go-ref/blob/master/field/fields.go
+	F := GF.NewFp2("BN254G2", "0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47")
+	F.Generator()
+}
+
 func TestSqrtF2(t *testing.T) {
 	var primes3mod4 = []int{59, 67, 71, 79, 83}
 	for _, p := range primes3mod4 {


### PR DESCRIPTION
Currently, `fp2.Elt` fails when given a string slice. I stumbled upon this trying to run SvdW on BLS12-381G2 without having precomputed Z.

I don't know this for a fact but the error could be due to a change in Go's type logic. I suspect that `[]string` used to be considered a subtype of `[]interface` but not anymore. Therefore when given a string slice, the slice processing part of `fp2.Elt` is bypassed and the entire slice is passed on to `fp.Elt`, which (understandably) panics.